### PR TITLE
Frontend

### DIFF
--- a/src/main/java/abod/obf/ObfuscatorController.java
+++ b/src/main/java/abod/obf/ObfuscatorController.java
@@ -3,65 +3,66 @@ package abod.obf;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PostMapping;
 
 @RestController
 public class ObfuscatorController {
  
   @GetMapping("/")
-  public String main() {
-    return "Hey! I am the Obfuscator!";
+  public String home() {
+    return "index";
   }
 
 
-  @GetMapping("/encode-py")
+  @PostMapping("/encode-py")
   public String obfPy(@RequestBody String input) {
     return Tricks.encode_Py(input);
   }
 
 
-  @GetMapping("/encode-ja")
+  @PostMapping("/encode-ja")
   public String obfJa(@RequestBody String input) {
     return Tricks.encode_Ja(input);
   }
 
 
-  @GetMapping("/encode-js")
+  @PostMapping("/encode-js")
   public String obfJs(@RequestBody String input) {
     return Tricks.encode_Js(input);
   }
 
 
-  @GetMapping("/encode-c")
+  @PostMapping("/encode-c")
   public String obfC(@RequestBody String input) {
     return Tricks.encode_C(input);
   }
 
 
-  @GetMapping("/encode-cs")
+  @PostMapping("/encode-cs")
   public String obfCs(@RequestBody String input) {
     return Tricks.encode_Cs(input);
   }
 
 
-  @GetMapping("/encode-ru")
+  @PostMapping("/encode-ru")
   public String obfRu(@RequestBody String input) {
 	return Tricks.encode_Ru(input);
   }
 
 
- @GetMapping("/encode-go")
+ @PostMapping("/encode-go")
   public String obfGo(@RequestBody String input) {
 	return Tricks.encode_Go(input);
   }
   
   
-  @GetMapping("/encode-da")
+  @PostMapping("/encode-da")
   public String obfDa(@RequestBody String input) {
   return Tricks.encode_Da(input);
   }
 
 
-  @GetMapping("/encode-cpp")
+  @PostMapping("/encode-cpp")
   public String obfCpp(@RequestBody String input) {
     return Tricks.encode_Cpp(input);
   }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -7,10 +7,11 @@
     <script>
          async function Obfuscatex() {
             const inputText = document.getElementById('inputText').value;
-            const response = await fetch('/encode-py', {
+            const lang_endp = document.getElementById('ChosenProg').value;
+            const response = await fetch(lang_endp, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(inputText)
+                body: inputText
             });
 
             if (response.ok) {
@@ -24,6 +25,19 @@
 </head>
 <body>
     <h2>Obfuscator X</h2>
+    <label for="ChosenProg">Language:</label><br>
+    <select id="ChosenProg">
+        <option value="/encode-py">Python</option>
+        <option value="/encode-ja">Java</option>
+        <option value="/encode-js">JavaScript</option>
+        <option value="/encode-c">C</option>
+        <option value="/encode-cs">C#</option>
+        <option value="/encode-ru">Rust</option>
+        <option value="/encode-go">Go</option>
+        <option value="/encode-da">Dart</option>
+        <option value="/encode-cpp">C++</option>
+    </select>
+    <br><br>
     <label for="inputText">String:</label><br>
     <textarea id="inputText" rows="5" cols="50"></textarea><br><br>
 

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,35 @@
+
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <title>Obfuscator X</title>
+    <script>
+         async function Obfuscatex() {
+            const inputText = document.getElementById('inputText').value;
+            const response = await fetch('/encode-py', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(inputText)
+            });
+
+            if (response.ok) {
+                const resultText = await response.text();
+                document.getElementById('resultText').value = resultText;
+            } else {
+                document.getElementById('resultText').value = 'Error calling server';
+            }
+        }
+   </script>
+</head>
+<body>
+    <h2>Obfuscator X</h2>
+    <label for="inputText">String:</label><br>
+    <textarea id="inputText" rows="5" cols="50"></textarea><br><br>
+
+    <button onclick="Obfuscatex()">Obfuscate</button><br><br>
+
+    <label for="resultText">Result:</label><br>
+    <textarea id="resultText" rows="5" cols="50" readonly></textarea>
+</body>
+</html>


### PR DESCRIPTION
This pull request introduces a frontend web interface for the obfuscator application and updates the backend API endpoints to use POST requests instead of GET. The main changes include adding a new HTML page for user interaction and modifying the controller methods to align with RESTful best practices.

Frontend addition:

* Added a new `index.html` file that provides a simple web interface for users to select a programming language, input a string, and receive the obfuscated result by making asynchronous POST requests to the backend endpoints.

Backend API updates:

* Changed all obfuscation endpoints in `ObfuscatorController.java` (e.g., `/encode-py`, `/encode-ja`, etc.) from `@GetMapping` to `@PostMapping` to properly handle input data in the request body and improve API design.
* Renamed the root endpoint handler method from `main` to `home` and changed its return value from a greeting string to `"index"`, likely to serve the new frontend page.